### PR TITLE
Fix: Correct cPanel deployment script to build the application

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -2,4 +2,6 @@
 deployment:
   tasks:
     - export DEPLOYPATH=/home/$CPANELUSER/public_html
-    - /bin/cp -R * $DEPLOYPATH
+    - npm install
+    - npm run build
+    - /bin/cp -R dist/* $DEPLOYPATH


### PR DESCRIPTION
- The live site was showing a directory listing ('Index of /') instead of the web application.
- The root cause was an incorrect deployment script in `.cpanel.yml` that copied the raw source code instead of the built application.
- This commit updates the deployment tasks to first install dependencies (`npm install`), then build the project (`npm run build`), and finally copy the contents of the `dist` directory to the server.
- This ensures that the compiled, static application is deployed, which will allow the web server to serve the `index.html` file correctly.